### PR TITLE
Add more coverage in shadowdog-local-cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepare": "npm run build",
     "prepublishOnly": "vitest run",
     "test": "vitest run --silent",
-    "test:watch": "vitest --silent",
+    "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint",
     "lint:inspect-config": "eslint --inspect-config",

--- a/src/plugins/shadowdog-local-cache.test.ts
+++ b/src/plugins/shadowdog-local-cache.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra'
 import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
-import shadowdogLocalCache from './shadowdog-local-cache'
+import shadowdogLocalCache, { compressArtifact } from './shadowdog-local-cache'
 
 describe('shadowdog local cache', () => {
   const next = vi.fn(() => fs.writeFile('tmp/tests/artifacts/foo', 'foo'))
@@ -44,36 +44,77 @@ describe('shadowdog local cache', () => {
   })
 
   describe('when cache is present', () => {
-    beforeEach(() => {
-      fs.writeFileSync('tmp/tests/artifacts/foo', 'foo')
-      // TODO: Gzip things
-      fs.writeFileSync('tmp/tests/cache/0adeca2ac6.tar.gz', 'foo')
+    describe('when the artifact is a single file', () => {
+      beforeEach(async () => {
+        fs.writeFileSync('tmp/tests/artifacts/foo', 'foo')
+        await compressArtifact('tmp/tests/artifacts/foo', 'tmp/tests/cache/0adeca2ac6.tar.gz')
+        fs.rmSync('tmp/tests/artifacts', { recursive: true })
+      })
+
+      it('does not execute the next middleware', async () => {
+        await shadowdogLocalCache.middleware({
+          config: {
+            command: 'echo foo',
+            artifacts: [
+              {
+                output: 'tmp/tests/artifacts/foo',
+              },
+            ],
+            tags: [],
+            workingDirectory: '',
+          },
+          files: [],
+          invalidators: {
+            environment: [],
+            files: [],
+          },
+          next,
+          abort: () => {},
+          options: {
+            path: 'tmp/tests/cache',
+          },
+        })
+        expect(next).not.toHaveBeenCalled()
+        expect(fs.readFileSync('tmp/tests/artifacts/foo', 'utf8')).toBe('foo')
+      })
     })
 
-    it.skip('does not execute the next middleware', async () => {
-      await shadowdogLocalCache.middleware({
-        config: {
-          command: 'echo foo',
-          artifacts: [
-            {
-              output: 'tmp/tests/artifacts/foo',
-            },
-          ],
-          tags: [],
-          workingDirectory: '',
-        },
-        files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
-        next,
-        abort: () => {},
-        options: {
-          path: 'tmp/tests/cache',
-        },
+    describe('when the artifact is a folder with some files to ignore', () => {
+      beforeEach(async () => {
+        fs.writeFileSync('tmp/tests/artifacts/foo', 'foo')
+        fs.writeFileSync('tmp/tests/artifacts/bar', 'bar')
+        await compressArtifact('tmp/tests/artifacts', 'tmp/tests/cache/079138748b.tar.gz')
+        fs.rmSync('tmp/tests/artifacts', { recursive: true })
       })
-      expect(next).not.toHaveBeenCalled()
+
+      it('does not execute the next middleware', async () => {
+        await shadowdogLocalCache.middleware({
+          config: {
+            command: 'echo foo',
+            artifacts: [
+              {
+                output: 'tmp/tests/artifacts',
+                ignore: ['tmp/tests/artifacts/bar'],
+              },
+            ],
+            tags: [],
+            workingDirectory: '',
+          },
+          files: [],
+          invalidators: {
+            environment: [],
+            files: [],
+          },
+          next,
+          abort: () => {},
+          options: {
+            path: 'tmp/tests/cache',
+          },
+        })
+        expect(next).not.toHaveBeenCalled()
+        expect(fs.readFileSync('tmp/tests/artifacts/foo', 'utf8')).toBe('foo')
+        expect(fs.existsSync('tmp/tests/artifacts/bar')).toBe(false)
+      })
     })
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,5 +4,9 @@ export const logMessage = (message: string) => {
   console.log(message)
 }
 
+export const logError = (error: Error) => {
+  console.error(new Error(error.stack))
+}
+
 export const chalkFiles = (files: string[]) =>
   files.map((file) => `'${chalk.blue(file)}'`).join(', ')


### PR DESCRIPTION
## 🔑 What?

This adds more coverage to the `shadowdog-local-cache` plugin covering some edge cases such as restoring cache from some folder that ignores some files.

