### PR TITLE
Add env var to configure local cache path

### DIFF
--- a/src/plugins/shadowdog-local-cache.ts
+++ b/src/plugins/shadowdog-local-cache.ts
@@ -184,6 +184,8 @@ const middleware: Middleware<PluginOptions> = async ({
 
   const mergedOptions = pluginOptionsSchema.parse(options)
 
+  mergedOptions.path = process.env.SHADOWDOG_LOCAL_CACHE_PATH ?? mergedOptions.path
+
   const currentCache = computeCache([...files, ...invalidators.files], invalidators.environment)
 
   fs.mkdirpSync(mergedOptions.path)


### PR DESCRIPTION
## 🔑 What?

This adds the option to override the local cache path using an env var. This is useful to override this in specific environments without changing the config file.