### PR TITLE
Fix issue in decompress artifact when output path do not exist

### DIFF
--- a/src/plugins/shadowdog-remote-aws-s3-cache.ts
+++ b/src/plugins/shadowdog-remote-aws-s3-cache.ts
@@ -91,10 +91,13 @@ const restoreRemoteCache = async (
 ) => {
   try {
     const stream = await client.getObject(bucket, objectName)
+    const outputPath = path.join(process.cwd(), artifact.output, '..')
+
+    fs.mkdirpSync(outputPath)
 
     stream.pipe(
       tar.extract({
-        cwd: path.join(process.cwd(), artifact.output, '..'),
+        cwd: outputPath,
         filter: (filePath) => filterFn(artifact.ignore, artifact.output, filePath),
       }),
     )


### PR DESCRIPTION
## Describe your changes

This makes sure we create the output path for the artifact when we are decompressing it from the remote cache.


