### PR TITLE
Use proper typing for shadowdog events

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from 'node:events'
+import { ArtifactConfig } from './config'
 
-type ShadowdogEvents = Record<
-  'initialized' | 'exit' | 'begin' | 'end' | 'error' | 'changed',
-  // TODO: review this
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  any
->
+type ShadowdogEvents = {
+  initialized: []
+  exit: [number?]
+  begin: [{ artifacts: ArtifactConfig[] }]
+  end: [{ artifacts: ArtifactConfig[] }]
+  error: [{ artifacts: ArtifactConfig[]; errorMessage: string }]
+  changed: [{ path: string; type: 'add' | 'change' | 'unlink' }]
+}
 
 export class ShadowdogEventEmitter extends EventEmitter<ShadowdogEvents> {}

--- a/src/plugins/shadowdog-socket.ts
+++ b/src/plugins/shadowdog-socket.ts
@@ -3,7 +3,6 @@ import { Listener } from '.'
 import * as net from 'net'
 import { logMessage } from '../utils'
 import chalk from 'chalk'
-import { ArtifactConfig } from '../config'
 
 type Event =
   | {
@@ -70,7 +69,7 @@ const listener: Listener<PluginOptions> = (shadowdogEventListener, options) => {
     notifyState(mergedOptions.path, {
       type: 'CHANGED_FILE',
       payload: {
-        file: payload.artifacts.map((artifact: ArtifactConfig) => artifact.output).join(', '),
+        file: payload.artifacts.map((artifact) => artifact.output).join(', '),
         ready: false,
       },
     })
@@ -80,7 +79,7 @@ const listener: Listener<PluginOptions> = (shadowdogEventListener, options) => {
     notifyState(mergedOptions.path, {
       type: 'CHANGED_FILE',
       payload: {
-        file: payload.artifacts.map((artifact: ArtifactConfig) => artifact.output).join(', '),
+        file: payload.artifacts.map((artifact) => artifact.output).join(', '),
         ready: true,
       },
     })
@@ -90,7 +89,7 @@ const listener: Listener<PluginOptions> = (shadowdogEventListener, options) => {
     notifyState(mergedOptions.path, {
       type: 'ERROR',
       payload: {
-        file: payload.artifacts.map((artifact: ArtifactConfig) => artifact.output).join(', '),
+        file: payload.artifacts.map((artifact) => artifact.output).join(', '),
         errorMessage: payload.errorMessage,
       },
     })


### PR DESCRIPTION

## Describe your changes

This removes an any type that we were using for the shadowdog events payload and types it accordingly.

