### PR TITLE
Add more granurality to the cache access

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -52,6 +52,14 @@
                   "path": {
                     "type": "string",
                     "default": "/tmp/shadowdog/cache"
+                  },
+                  "read": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "write": {
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 "additionalProperties": false,
@@ -77,6 +85,14 @@
                   },
                   "bucketName": {
                     "type": "string"
+                  },
+                  "read": {
+                    "type": "boolean",
+                    "default": true
+                  },
+                  "write": {
+                    "type": "boolean",
+                    "default": true
                   }
                 },
                 "required": ["bucketName"],

--- a/src/pluginTypes.ts
+++ b/src/pluginTypes.ts
@@ -4,13 +4,21 @@ export const pluginOptionsSchema = z.discriminatedUnion('name', [
   z.object({ name: z.literal('shadowdog-rake'), options: z.object({}).optional() }),
   z.object({
     name: z.literal('shadowdog-local-cache'),
-    options: z.object({ path: z.string().default('/tmp/shadowdog/cache') }).default({}),
+    options: z
+      .object({
+        path: z.string().default('/tmp/shadowdog/cache'),
+        read: z.boolean().default(true),
+        write: z.boolean().default(true),
+      })
+      .default({}),
   }),
   z.object({
     name: z.literal('shadowdog-remote-aws-s3-cache'),
     options: z.object({
       path: z.string().default('shadowdog/cache'),
       bucketName: z.string(),
+      read: z.boolean().default(true),
+      write: z.boolean().default(true),
     }),
   }),
   z.object({ name: z.literal('shadowdog-tag'), options: z.object({}).optional() }),

--- a/src/plugins/shadowdog-local-cache.test.ts
+++ b/src/plugins/shadowdog-local-cache.test.ts
@@ -47,6 +47,8 @@ describe('shadowdog local cache', () => {
         abort: () => {},
         options: {
           path: 'tmp/tests/cache',
+          read: true,
+          write: true,
         },
       })
       expect(next).toHaveBeenCalled()
@@ -82,6 +84,8 @@ describe('shadowdog local cache', () => {
           abort: () => {},
           options: {
             path: 'tmp/tests/cache',
+            read: true,
+            write: true,
           },
         })
         expect(next).not.toHaveBeenCalled()
@@ -119,6 +123,8 @@ describe('shadowdog local cache', () => {
           abort: () => {},
           options: {
             path: 'tmp/tests/cache',
+            read: true,
+            write: true,
           },
         })
         expect(next).not.toHaveBeenCalled()
@@ -159,6 +165,8 @@ describe('shadowdog local cache', () => {
         abort: () => {},
         options: {
           path: 'tmp/tests/cache',
+          read: true,
+          write: true,
         },
       })
       expect(fs.existsSync('tmp/tests/cache/0adeca2ac6.tar.gz')).toBe(false)


### PR DESCRIPTION
## Describe your changes

This adds some additional config that can control if we read or write from the local and the remote cache.

This config can be overriden by env vars. This is very useful for CI systems.