### PR TITLE
Fix: listen to add events in chokidar

### DIFF
--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -115,7 +115,10 @@ const setupWatchers = (config: ConfigFile, eventEmitter: ShadowdogEventEmitter) 
             resolve(watcher)
           }
 
-          watcher.on('change', debounce(onFileChange, config.debounceTime))
+          const debouncedOnFileChange = debounce(onFileChange, config.debounceTime)
+
+          watcher.on('add', debouncedOnFileChange)
+          watcher.on('change', debouncedOnFileChange)
           watcher.on('ready', onReady)
           watcher.on('error', reject)
         })


### PR DESCRIPTION
## Describe your changes

This makes sure we are listening `add` events in a same fashion as `change` events so we can capture new files that were created in the generation process.