### PR TITLE
Improve shadowdog-lock errors

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -32,4 +32,6 @@ jobs:
         run: npm test
 
       - name: Generate (forgot to update src/config/schema.json)
+        env:
+          DEBUG: ${{ runner.debug }}
         run: npm run generate && git diff --exit-code

--- a/shadowdog.json
+++ b/shadowdog.json
@@ -2,6 +2,9 @@
   "$schema": "schema.json",
   "plugins": [
     {
+      "name": "shadowdog-lock"
+    },
+    {
       "name": "shadowdog-local-cache"
     }
   ],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,17 @@ import pjson from '../package.json'
 import path from 'path'
 import { runDaemon } from './daemon'
 import { generate } from './generate'
-import { logError, logMessage, readShadowdogVersion } from './utils'
+import { logError, logMessage, readShadowdogVersion, exit } from './utils'
 import chalk from 'chalk'
+import { ShadowdogEventEmitter } from './events'
+import { filterEventListenerPlugins } from './plugins'
+import { loadConfig } from './config'
 
 const DEFAULT_CONFIG_FILENAME = 'shadowdog.json'
 
 const cli = new Command()
+
+const eventEmitter = new ShadowdogEventEmitter()
 
 cli.version(pjson.version).description('TBA')
 
@@ -23,31 +28,41 @@ cli
     '-w, --watch',
     'Watch for changes in the configured files and run the tasks automatically',
   )
-  .action(async ({ config, watch }) => {
+  .action(async ({ config: configFilePath, watch }) => {
     if (watch) {
       logMessage(
         `
-    ███████╗██╗  ██╗ █████╗ ██████╗  ██████╗ ██╗    ██╗██████╗  ██████╗  ██████╗ 
-    ██╔════╝██║  ██║██╔══██╗██╔══██╗██╔═══██╗██║    ██║██╔══██╗██╔═══██╗██╔════╝ 
+    ███████╗██╗  ██╗ █████╗ ██████╗  ██████╗ ██╗    ██╗██████╗  ██████╗  ██████╗
+    ██╔════╝██║  ██║██╔══██╗██╔══██╗██╔═══██╗██║    ██║██╔══██╗██╔═══██╗██╔════╝
     ███████╗███████║███████║██║  ██║██║   ██║██║ █╗ ██║██║  ██║██║   ██║██║  ███╗
     ╚════██║██╔══██║██╔══██║██║  ██║██║   ██║██║███╗██║██║  ██║██║   ██║██║   ██║
     ███████║██║  ██║██║  ██║██████╔╝╚██████╔╝╚███╔███╔╝██████╔╝╚██████╔╝╚██████╔╝
-    ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚══╝╚══╝ ╚═════╝  ╚═════╝  ╚═════╝ 
+    ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚═════╝  ╚═════╝  ╚══╝╚══╝ ╚═════╝  ╚═════╝  ╚═════╝
     `,
       )
     }
 
     logMessage(`🚀 Shadowdog ${chalk.blue(readShadowdogVersion())} is booting!`)
 
+    const configRelativePath = path.relative(process.cwd(), configFilePath)
+    const config = loadConfig(configRelativePath)
+
+    filterEventListenerPlugins(config.plugins).forEach(({ fn, options }) => {
+      fn.listener(eventEmitter, options ?? {})
+    })
+
     try {
-      await generate(path.relative(process.cwd(), config))
+      await generate(config, eventEmitter)
     } catch (error: unknown) {
       logMessage(`🚫 Unable to perform the initial generation because some command has failed.`)
       logError(error as Error)
+      return exit(eventEmitter, 1)
     }
 
     if (watch) {
-      runDaemon(path.relative(process.cwd(), config))
+      runDaemon(config, configRelativePath, eventEmitter)
+    } else {
+      return exit(eventEmitter, 0)
     }
   })
 

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -30,7 +30,7 @@ export type Middleware<Options = unknown> = (control: {
   next: () => Promise<unknown>
   abort: () => void
   changedFilePath?: string
-  eventEmitter?: ShadowdogEventEmitter
+  eventEmitter: ShadowdogEventEmitter
 }) => Promise<unknown>
 
 type PluginsMap = {

--- a/src/plugins/shadowdog-git.test.ts
+++ b/src/plugins/shadowdog-git.test.ts
@@ -2,9 +2,11 @@ import fs from 'fs-extra'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import shadowdogGit from './shadowdog-git'
 import process from 'process'
+import { ShadowdogEventEmitter } from '../events'
 
 describe('shadowdog git', () => {
   const next = vi.fn()
+  const eventEmitter = new ShadowdogEventEmitter()
 
   beforeEach(() => {
     fs.mkdirpSync('tmp/.git')
@@ -34,6 +36,7 @@ describe('shadowdog git', () => {
         abort: () => {},
         options: {},
         changedFilePath: 'README.md',
+        eventEmitter,
       })
       expect(next).not.toHaveBeenCalled()
     })

--- a/src/plugins/shadowdog-local-cache.test.ts
+++ b/src/plugins/shadowdog-local-cache.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra'
 import { describe, it, beforeEach, afterEach, vi, expect, afterAll } from 'vitest'
 import shadowdogLocalCache, { compressArtifact } from './shadowdog-local-cache'
+import { ShadowdogEventEmitter } from '../events'
 
 vi.mock('../utils', async () => {
   const utils = await vi.importActual('../utils')
@@ -14,6 +15,7 @@ vi.mock('../utils', async () => {
 
 describe('shadowdog local cache', () => {
   const next = vi.fn(() => fs.writeFile('tmp/tests/artifacts/foo', 'foo'))
+  const eventEmitter = new ShadowdogEventEmitter()
 
   beforeEach(() => {
     fs.mkdirpSync('tmp/tests/cache')
@@ -50,6 +52,7 @@ describe('shadowdog local cache', () => {
           read: true,
           write: true,
         },
+        eventEmitter,
       })
       expect(next).toHaveBeenCalled()
     })
@@ -87,6 +90,7 @@ describe('shadowdog local cache', () => {
             read: true,
             write: true,
           },
+          eventEmitter,
         })
         expect(next).not.toHaveBeenCalled()
         expect(fs.readFileSync('tmp/tests/artifacts/foo', 'utf8')).toBe('foo')
@@ -126,6 +130,7 @@ describe('shadowdog local cache', () => {
             read: true,
             write: true,
           },
+          eventEmitter,
         })
         expect(next).not.toHaveBeenCalled()
         expect(fs.readFileSync('tmp/tests/artifacts/foo', 'utf8')).toBe('foo')
@@ -168,6 +173,7 @@ describe('shadowdog local cache', () => {
           read: true,
           write: true,
         },
+        eventEmitter,
       })
       expect(fs.existsSync('tmp/tests/cache/0adeca2ac6.tar.gz')).toBe(false)
       expect(fs.existsSync('tmp/tests/cache_overriden/0adeca2ac6.tar.gz')).toBe(true)

--- a/src/plugins/shadowdog-socket.ts
+++ b/src/plugins/shadowdog-socket.ts
@@ -34,7 +34,9 @@ const notifyState = (socketPath: string, event: Event) => {
     if (!brokenSocketNotified) {
       brokenSocketNotified = true
 
-      logMessage(`🚫 Socket file at ${chalk.blue(socketPath)} does not exist`)
+      logMessage(
+        `⚠️ Socket file at ${chalk.blue(socketPath)} does not exist. Shadowdog will not be able to notify the state of the build.`,
+      )
     }
 
     return Promise.resolve()

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -6,7 +6,7 @@ interface Options {
   files: string[]
   invalidators: InvalidatorConfig
   config: CommandConfig
-  eventEmitter?: ShadowdogEventEmitter
+  eventEmitter: ShadowdogEventEmitter
   changedFilePath?: string
 }
 export class TaskRunner {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -6,10 +6,17 @@ interface Options {
   command: string
   workingDirectory: string
   changedFilePath?: string
-  onSpawn?: (task: childProcess.ChildProcess) => void
+  onSpawn: (task: childProcess.ChildProcess) => void
+  onExit: (task: childProcess.ChildProcess) => void
 }
 
-export const runTask = ({ command, workingDirectory, changedFilePath, onSpawn }: Options) => {
+export const runTask = ({
+  command,
+  workingDirectory,
+  changedFilePath,
+  onSpawn,
+  onExit,
+}: Options) => {
   return new Promise<void>((resolve, reject) => {
     const fullCommand = changedFilePath ? command.replace('$FILE', changedFilePath) : command
     let errorMessage = ''
@@ -24,9 +31,7 @@ export const runTask = ({ command, workingDirectory, changedFilePath, onSpawn }:
 
     logMessage(`🏭️ Running command (PID: ${chalk.magenta(task.pid)}) '${chalk.blue(command)}'`)
 
-    if (onSpawn) {
-      onSpawn(task)
-    }
+    onSpawn(task)
 
     task.stderr.on('data', (data) => (errorMessage += data.toString()))
 
@@ -40,6 +45,8 @@ export const runTask = ({ command, workingDirectory, changedFilePath, onSpawn }:
           )}' has exited successfully ${chalk.cyan(`(${seconds}s)`)}`,
         )
 
+        onExit(task)
+
         return resolve()
       }
 
@@ -50,6 +57,8 @@ export const runTask = ({ command, workingDirectory, changedFilePath, onSpawn }:
       if (errorMessage) {
         logMessage(errorMessage)
       }
+
+      onExit(task)
 
       return reject(new Error(errorMessage))
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import fs from 'fs'
 import path from 'path'
+import { ShadowdogEventEmitter } from './events'
 
 export const logMessage = (message: string) => {
   console.log(message)
@@ -19,4 +20,12 @@ export const readShadowdogVersion = () => {
   const packageJsonPath = path.resolve(__dirname, '../package.json')
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
   return packageJson.version
+}
+
+export const exit = async (eventEmitter: ShadowdogEventEmitter, code: number) => {
+  // emit exit event and wait for all listeners to complete
+  await Promise.all(eventEmitter.listeners('exit').map((listener) => listener()))
+  eventEmitter.removeAllListeners()
+
+  process.exit(code)
 }


### PR DESCRIPTION
This makes sure we throw an error when the lock is found. It also fixes an issue where the exit code was not properly set when the generate was failing.
