### PR TITLE
Add continue on error option for generate

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,7 +52,7 @@ cli
     })
 
     try {
-      await generate(config, eventEmitter)
+      await generate(config, eventEmitter, { continueOnError: watch })
     } catch (error: unknown) {
       logMessage(`🚫 Unable to perform the initial generation because some command has failed.`)
       logError(error as Error)


### PR DESCRIPTION
This adds a new option to the generate command that allow shadowdog to continue the execution if there is any error.
