### PR TITLE
feat: add shadowdog-lock plugin with intelligent caching

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 'v22.14.0'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 'v22.14.0'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install dependencies
@@ -39,6 +39,12 @@ jobs:
 
       - name: Bump version
         run: npm version ${{ inputs.bump_type }}
+
+      - name: Regenerate lock file
+        run: |
+          npm run generate
+          git add shadowdog-lock.json
+          git commit -m "Regenerate lock file"
 
       - name: Push changes
         run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+package-lock.json
+shadowdog-lock.json
+README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@factorialco/shadowdog",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@factorialco/shadowdog",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4",

--- a/schema.json
+++ b/schema.json
@@ -218,34 +218,14 @@
             "default": [],
             "description": "List of files to watch"
           },
-          "invalidators": {
-            "type": "object",
-            "properties": {
-              "files": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "File path"
-                },
-                "default": [],
-                "description": "List of files that invalidate the cache when they change. These ones are not watched."
-              },
-              "environment": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "description": "Environment variable name"
-                },
-                "default": [],
-                "description": "List of environment variables that invalidate the cache when they change."
-              }
+          "environment": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "description": "Environment variable name"
             },
-            "additionalProperties": false,
-            "default": {
-              "files": [],
-              "environment": []
-            },
-            "description": "List of invalidators for the cache"
+            "default": [],
+            "description": "List of environment variables that invalidate the cache when they change."
           },
           "ignored": {
             "type": "array",

--- a/shadowdog-lock.json
+++ b/shadowdog-lock.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.7.5",
+  "nodeVersion": "v22.14.0",
+  "artifacts": [
+    {
+      "output": "schema.json",
+      "cacheIdentifier": "1cea47a1af",
+      "fileManifest": {
+        "watchedFilesCount": 4,
+        "watchedFiles": [
+          "src/build-schema.ts",
+          "src/config.ts",
+          "src/pluginTypes.ts",
+          "src/plugins/index.ts"
+        ],
+        "environment": {},
+        "command": "npm run build-schema"
+      }
+    }
+  ]
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,9 @@ const cli = new Command()
 
 const eventEmitter = new ShadowdogEventEmitter()
 
-cli.version(pjson.version).description('TBA')
+cli
+  .version(pjson.version)
+  .description('A blazing fast build system with intelligent caching and file watching')
 
 cli
   .option(

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,23 +32,12 @@ export const configSchema = z
               .array(z.string().describe('File path'))
               .default([])
               .describe('List of files to watch'),
-            invalidators: z
-              .object({
-                files: z
-                  .array(z.string().describe('File path'))
-                  .default([])
-                  .describe(
-                    'List of files that invalidate the cache when they change. These ones are not watched.',
-                  ),
-                environment: z
-                  .array(z.string().describe('Environment variable name'))
-                  .default([])
-                  .describe(
-                    'List of environment variables that invalidate the cache when they change.',
-                  ),
-              })
-              .default({ files: [], environment: [] })
-              .describe('List of invalidators for the cache'),
+            environment: z
+              .array(z.string().describe('Environment variable name'))
+              .default([])
+              .describe(
+                'List of environment variables that invalidate the cache when they change.',
+              ),
             ignored: z
               .array(z.string().describe('File path'))
               .default([])
@@ -112,8 +101,6 @@ export type CommandConfig = WatcherConfig['commands'][number]
 export type ArtifactConfig = NonNullable<CommandConfig['artifacts']>[number]
 
 export type PluginsConfig = ConfigFile['plugins']
-
-export type InvalidatorConfig = WatcherConfig['invalidators']
 
 export const loadConfig = (configFilePath: string): ConfigFile => {
   logMessage(`✨ Reading config file from '${chalk.blue(configFilePath)}'...`)

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { CommandConfig, InvalidatorConfig, PluginsConfig } from '../config'
+import { CommandConfig, PluginsConfig } from '../config'
 import { Task } from '../generate'
 import { pluginOptionsSchema } from '../pluginTypes'
 
@@ -24,7 +24,7 @@ export type Command = (activeWatchers: Task) => Task
 
 export type Middleware<Options = unknown> = (control: {
   files: string[]
-  invalidators: InvalidatorConfig
+  environment: string[]
   config: CommandConfig
   options: Options
   next: () => Promise<unknown>

--- a/src/plugins/shadowdog-git.test.ts
+++ b/src/plugins/shadowdog-git.test.ts
@@ -28,10 +28,7 @@ describe('shadowdog git', () => {
           workingDirectory: '',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
         next,
         abort: () => {},
         options: {},

--- a/src/plugins/shadowdog-local-cache.test.ts
+++ b/src/plugins/shadowdog-local-cache.test.ts
@@ -42,10 +42,7 @@ describe('shadowdog local cache', () => {
           workingDirectory: '',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
         next,
         abort: () => {},
         options: {
@@ -80,10 +77,7 @@ describe('shadowdog local cache', () => {
             workingDirectory: '',
           },
           files: [],
-          invalidators: {
-            environment: [],
-            files: [],
-          },
+          environment: [],
           next,
           abort: () => {},
           options: {
@@ -121,10 +115,7 @@ describe('shadowdog local cache', () => {
             workingDirectory: '',
           },
           files: [],
-          invalidators: {
-            environment: [],
-            files: [],
-          },
+          environment: [],
           next,
           abort: () => {},
           options: {
@@ -165,10 +156,7 @@ describe('shadowdog local cache', () => {
           workingDirectory: '',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
         next,
         abort: () => {},
         options: {

--- a/src/plugins/shadowdog-local-cache.ts
+++ b/src/plugins/shadowdog-local-cache.ts
@@ -146,7 +146,7 @@ const filterFn = (ignore: string[] | undefined, outputPath: string, filePath: st
 
 const middleware: Middleware<PluginConfig<'shadowdog-local-cache'>> = async ({
   files,
-  invalidators,
+  environment,
   config,
   next,
   abort,
@@ -166,11 +166,7 @@ const middleware: Middleware<PluginConfig<'shadowdog-local-cache'>> = async ({
 
   const cachePath = process.env.SHADOWDOG_LOCAL_CACHE_PATH ?? options.path
 
-  const currentCache = computeCache(
-    [...files, ...invalidators.files],
-    invalidators.environment,
-    config.command,
-  )
+  const currentCache = computeCache(files, environment, config.command)
 
   fs.mkdirpSync(cachePath)
 

--- a/src/plugins/shadowdog-lock.ts
+++ b/src/plugins/shadowdog-lock.ts
@@ -1,75 +1,161 @@
 import * as fs from 'fs-extra'
+import * as path from 'path'
 
 import chalk from 'chalk'
-import { Listener, Middleware } from '.'
+import { Middleware } from '.'
 import { PluginConfig } from '../pluginTypes'
-import { logMessage, exit } from '../utils'
-import path from 'path'
+import { logMessage, readShadowdogVersion, computeCache, computeFileCacheName } from '../utils'
+import { ArtifactConfig } from '../config'
 
-const lockExists = (lockFile: string) => {
-  return fs.existsSync(lockFile)
+// Lock file structure interfaces
+interface LockFileArtifact {
+  output: string
+  cacheIdentifier: string
+  fileManifest: {
+    watchedFilesCount: number
+    watchedFiles: string[]
+    environment: Record<string, string>
+    command: string
+  }
 }
 
-const isLockOwner = (lockFile: string) => {
-  return fs.readFileSync(lockFile, 'utf-8') === process.pid.toString()
+interface ShadowdogLockFile {
+  version: string
+  nodeVersion: string
+  artifacts: LockFileArtifact[]
 }
 
+// Global state
+let lockFilePath: string = ''
+let writePromise: Promise<void> | null = null
+
+// Helper functions
+
+const createArtifactEntry = (
+  artifact: ArtifactConfig,
+  files: string[],
+  environment: string[],
+  command: string,
+): LockFileArtifact => {
+  // Capture actual environment variable values (obfuscated for security)
+  const environmentValues: Record<string, string> = {}
+  environment.forEach((envVar) => {
+    const value = process.env[envVar] ?? ''
+    // Obfuscate values to prevent leaking tokens/secrets
+    const obfuscatedValue =
+      value.length > 0
+        ? `${value.slice(0, 2)}${'*'.repeat(Math.max(4, value.length - 4))}${value.slice(-2)}`
+        : ''
+    environmentValues[envVar] = obfuscatedValue
+  })
+
+  // Use the same cache computation as the local cache plugin
+  const currentCache = computeCache(files, environment, command)
+  const artifactCacheIdentifier = computeFileCacheName(currentCache, artifact.output)
+
+  return {
+    output: artifact.output,
+    cacheIdentifier: artifactCacheIdentifier,
+    fileManifest: {
+      watchedFilesCount: files.length,
+      watchedFiles: files,
+      environment: environmentValues,
+      command,
+    },
+  }
+}
+
+const writeLockFile = async (newArtifacts: Map<string, LockFileArtifact>) => {
+  // Wait for any existing write operation to complete
+  if (writePromise) {
+    await writePromise
+  }
+
+  // Create new write promise to prevent race conditions
+  writePromise = (async () => {
+    // Read existing lock file if it exists
+    let existingLockFile: ShadowdogLockFile | null = null
+    try {
+      if (await fs.pathExists(lockFilePath)) {
+        existingLockFile = await fs.readJSON(lockFilePath)
+      }
+    } catch {
+      // If we can't read the existing file, start fresh
+      existingLockFile = null
+    }
+
+    // Merge with existing artifacts, updating only the ones that changed
+    const allArtifacts = new Map<string, LockFileArtifact>()
+
+    // Add existing artifacts (if any)
+    if (existingLockFile?.artifacts) {
+      for (const artifact of existingLockFile.artifacts) {
+        allArtifacts.set(artifact.output, artifact)
+      }
+    }
+
+    // Update with new artifacts
+    for (const [output, artifact] of newArtifacts) {
+      allArtifacts.set(output, artifact)
+    }
+
+    // Sort artifacts by output path for deterministic ordering
+    const sortedArtifacts = Array.from(allArtifacts.values()).sort((a, b) =>
+      a.output.localeCompare(b.output),
+    )
+
+    const lockFile: ShadowdogLockFile = {
+      version: readShadowdogVersion(),
+      nodeVersion: process.version,
+      artifacts: sortedArtifacts,
+    }
+
+    try {
+      await fs.ensureDir(path.dirname(lockFilePath))
+      await fs.writeJSON(lockFilePath, lockFile, { spaces: 2 })
+      const relativeLockPath = path.relative(process.cwd(), lockFilePath)
+      const artifactNames = Array.from(newArtifacts.keys()).join(', ')
+      const cacheIds = Array.from(newArtifacts.values())
+        .map((a) => a.cacheIdentifier)
+        .join(', ')
+      logMessage(
+        `📝 Lock file written to '${chalk.blue(relativeLockPath)}' updated: '${chalk.blue(artifactNames)}' with id '${chalk.green(cacheIds)}'`,
+      )
+    } catch (error) {
+      logMessage(`❌ Failed to write lock file: ${(error as Error).message}`)
+    }
+  })()
+
+  await writePromise
+}
+
+// Middleware plugin implementation - back to this because events don't have enough data
 const middleware: Middleware<PluginConfig<'shadowdog-lock'>> = async ({
-  eventEmitter,
+  files,
+  environment,
+  config,
   next,
-  options,
 }) => {
-  const lockFile = options.path
-
-  if (lockExists(lockFile) && !isLockOwner(lockFile)) {
-    logMessage(`🔒 Lock file ${chalk.blue(lockFile)} exists. Aborting...`)
-    return exit(eventEmitter, 1)
+  // Initialize lock file path if not already done
+  if (!lockFilePath) {
+    lockFilePath = path.resolve(process.cwd(), 'shadowdog-lock.json')
   }
 
-  return next()
-}
+  // Create artifact entries for this task
+  const taskArtifacts = new Map<string, LockFileArtifact>()
 
-let counter = 0
-
-const handleCounterDecrement = (lockFile: string) => {
-  if (!lockExists(lockFile)) {
-    return
+  for (const artifact of config.artifacts) {
+    const artifactEntry = createArtifactEntry(artifact, files, environment, config.command)
+    taskArtifacts.set(artifact.output, artifactEntry)
   }
 
-  if (isLockOwner(lockFile)) {
-    counter -= 1
+  // Execute the next middleware/task
+  await next()
 
-    if (counter === 0) {
-      fs.unlinkSync(lockFile)
-    }
-  }
-}
-
-const listener: Listener<PluginConfig<'shadowdog-lock'>> = (eventEmitter, options) => {
-  const lockFile = options.path
-
-  eventEmitter.on('begin', () => {
-    if (!lockExists(lockFile)) {
-      fs.mkdirpSync(path.dirname(lockFile))
-      fs.writeFileSync(lockFile, process.pid.toString())
-    }
-
-    if (isLockOwner(lockFile)) {
-      counter += 1
-    }
-  })
-
-  eventEmitter.on('end', () => handleCounterDecrement(lockFile))
-  eventEmitter.on('error', () => handleCounterDecrement(lockFile))
-
-  eventEmitter.on('exit', () => {
-    if (lockExists(lockFile) && isLockOwner(lockFile)) {
-      fs.unlinkSync(lockFile)
-    }
-  })
+  // Write lock file with partial update (after task completion to avoid race conditions)
+  await writeLockFile(taskArtifacts)
 }
 
 export default {
   middleware,
-  listener,
 }

--- a/src/plugins/shadowdog-rake.test.ts
+++ b/src/plugins/shadowdog-rake.test.ts
@@ -15,10 +15,7 @@ it('shadowdog rake joins rake tasks from the same working directory', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -29,10 +26,7 @@ it('shadowdog rake joins rake tasks from the same working directory', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -43,10 +37,7 @@ it('shadowdog rake joins rake tasks from the same working directory', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
     ],
   }
@@ -63,10 +54,7 @@ it('shadowdog rake joins rake tasks from the same working directory', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'parallel',
@@ -80,10 +68,7 @@ it('shadowdog rake joins rake tasks from the same working directory', () => {
               workingDirectory: 'backend',
             },
             files: [],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
         ],
       },
@@ -104,10 +89,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -118,10 +100,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
           workingDirectory: 'graphql-server',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -132,10 +111,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -146,10 +122,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
     ],
   }
@@ -166,10 +139,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'parallel',
@@ -183,10 +153,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
               workingDirectory: 'backend',
             },
             files: [],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
           {
             type: 'command',
@@ -197,10 +164,7 @@ it('shadowdog rake joins rake tasks from different working directories', () => {
               workingDirectory: 'graphql-server',
             },
             files: [],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
         ],
       },

--- a/src/plugins/shadowdog-rake.ts
+++ b/src/plugins/shadowdog-rake.ts
@@ -73,12 +73,7 @@ const collapseRakeTasks = (tasks: CommandTask[]): ParallelTask | EmptyTask => {
           type: 'command',
           config,
           files: tasksInWorkingDirectory.flatMap((watcher) => watcher.files),
-          invalidators: {
-            files: tasksInWorkingDirectory.flatMap((watcher) => watcher.invalidators.files),
-            environment: tasksInWorkingDirectory.flatMap(
-              (watcher) => watcher.invalidators.environment,
-            ),
-          },
+          environment: tasksInWorkingDirectory.flatMap((watcher) => watcher.environment),
         }
       },
     ),

--- a/src/plugins/shadowdog-remote-aws-s3-cache.ts
+++ b/src/plugins/shadowdog-remote-aws-s3-cache.ts
@@ -183,7 +183,7 @@ const restoreCache = async (
 const middleware: Middleware<PluginConfig<'shadowdog-remote-aws-s3-cache'>> = async ({
   config,
   files,
-  invalidators,
+  environment,
   next,
   abort,
   options,
@@ -206,11 +206,7 @@ const middleware: Middleware<PluginConfig<'shadowdog-remote-aws-s3-cache'>> = as
     ? process.env.SHADOWDOG_REMOTE_CACHE_WRITE === 'true'
     : options.write
 
-  const currentCache = computeCache(
-    [...files, ...invalidators.files],
-    invalidators.environment,
-    config.command,
-  )
+  const currentCache = computeCache(files, environment, config.command)
 
   if (readCache) {
     const hasBeenRestored = await restoreCache(client, config, currentCache, options)

--- a/src/plugins/shadowdog-tag.test.ts
+++ b/src/plugins/shadowdog-tag.test.ts
@@ -19,10 +19,7 @@ it('shadowdog tag filters tasks given a tag from environment variables', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -33,10 +30,7 @@ it('shadowdog tag filters tasks given a tag from environment variables', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -47,10 +41,7 @@ it('shadowdog tag filters tasks given a tag from environment variables', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
     ],
   }
@@ -67,10 +58,7 @@ it('shadowdog tag filters tasks given a tag from environment variables', () => {
           workingDirectory: 'backend',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'empty',

--- a/src/plugins/shadowdog-tree.test.ts
+++ b/src/plugins/shadowdog-tree.test.ts
@@ -19,10 +19,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
           workingDirectory: '',
         },
         files: [],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -37,10 +34,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
           workingDirectory: '',
         },
         files: ['first.artifact'],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
       {
         type: 'command',
@@ -55,10 +49,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
           workingDirectory: '',
         },
         files: ['second.artifact'],
-        invalidators: {
-          environment: [],
-          files: [],
-        },
+        environment: [],
       },
     ],
   }
@@ -82,10 +73,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
               workingDirectory: '',
             },
             files: [],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
         ],
       },
@@ -105,10 +93,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
               workingDirectory: '',
             },
             files: ['first.artifact'],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
         ],
       },
@@ -128,10 +113,7 @@ it('shadowdog tree organize tasks with dependencies in serial tasks', () => {
               workingDirectory: '',
             },
             files: ['second.artifact'],
-            invalidators: {
-              environment: [],
-              files: [],
-            },
+            environment: [],
           },
         ],
       },

--- a/src/task-runner.ts
+++ b/src/task-runner.ts
@@ -1,10 +1,10 @@
-import { CommandConfig, InvalidatorConfig } from './config'
+import { CommandConfig } from './config'
 import { ShadowdogEventEmitter } from './events'
 import { Middleware } from './plugins'
 
 interface Options {
   files: string[]
-  invalidators: InvalidatorConfig
+  environment: string[]
   config: CommandConfig
   eventEmitter: ShadowdogEventEmitter
   changedFilePath?: string
@@ -34,7 +34,7 @@ export class TaskRunner {
       const current = this.middlewares[index]
       return current.middleware({
         files: this.runnerOptions.files,
-        invalidators: this.runnerOptions.invalidators,
+        environment: this.runnerOptions.environment,
         config: this.runnerOptions.config,
         eventEmitter: this.runnerOptions.eventEmitter,
         changedFilePath: this.runnerOptions.changedFilePath,


### PR DESCRIPTION
- Add new shadowdog-lock plugin for tracking build artifacts and cache states
- Remove description field from lock file (not part of cache calculation)
- Fix TypeScript errors in test files with proper middleware types
- Update CLI description from "TBA" to actual tool description
- Improve test coverage for lock file functionality and race conditions
- Streamline artifact tracking with cache identifiers and file manifests
