### PR TITLE
fix: use node 24 in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci


### PR DESCRIPTION
## Summary

- Updates publish.yml to use node 24 (matching specbanditjs exactly)
- The v0.9.5 publish failed with E404 — this aligns the workflow with the working specbanditjs configuration